### PR TITLE
Implement swiping circle navigation logic

### DIFF
--- a/js/circle-helper.js
+++ b/js/circle-helper.js
@@ -1,0 +1,54 @@
+/*global tau */
+/*jslint unparam: true */
+document.addEventListener("tauinit", function () {
+
+	// This logic works only on circular device.
+	if (tau.support.shape.circle) {
+		/**
+		 * pagebeforeshow event handler
+		 * Do preparatory works and adds event listeners
+		 */
+		document.addEventListener("pagebeforeshow", function (event) {
+			/**
+			 * page - Active page element
+			 * list - NodeList object for lists in the page
+			 */
+			var page = event.target,
+				pageWidget = tau.widget.Page(page),
+				pageId = page.id,
+				list;
+
+			if (pageWidget.option("enablePageScroll")) {
+				tau.util.rotaryScrolling.enable(page.querySelector(".ui-scroller"));
+			}
+
+			if (!page.classList.contains("page-snaplistview") &&
+				pageId !== "page-snaplistview" &&
+				pageId !== "page-swipelist" &&
+				pageId !== "page-marquee-list" &&
+				pageId !== "page-multiline-list" &&
+				pageId !== "drawer-page") {
+				list = page.querySelector(".ui-listview");
+				if (list) {
+					tau.widget.Listview(list);
+				}
+			}
+		}, true);
+		document.addEventListener("pagebeforehide", function (event) {
+			var page = event.target,
+				pageWidget = tau.widget.Page(page);
+
+			if (pageWidget.option("enablePageScroll")) {
+				tau.util.rotaryScrolling.disable(page.querySelector(".ui-scroller"));
+			}
+		});
+		document.addEventListener("popupshow", function (event) {
+			var popup = event.target;
+
+			tau.util.rotaryScrolling.enable(popup.querySelector(".ui-popup-wrapper"));
+		});
+		document.addEventListener("popuphide", function () {
+			tau.util.rotaryScrolling.disable();
+		});
+	}
+});

--- a/js/hsection.js
+++ b/js/hsection.js
@@ -1,0 +1,51 @@
+/*global tau */
+var sectionChanger,
+	pageIndicator,
+	pageIndicatorHandler;
+
+var PAGE_REMOTE_HOME = 0,
+	PAGE_REMOTE_NAVIGATION = 1,
+	PAGE_REMOTE_PLAYBACK = 2,
+	PAGE_REMOTE_SWIPE_CONTROL = 3,
+	PAGE_SETTINGS = 4;
+
+(function () {
+	var page = document.getElementById("home-page"),
+		changer = document.getElementById("hsectionchanger"),
+		sectionLength = document.querySelectorAll("section").length,
+		elPageIndicator = document.getElementById("pageIndicator");
+
+	/**
+	 * pagebeforeshow event handler
+	 * Do preparatory works and adds event listeners
+	 */
+	page.addEventListener("pagebeforeshow", function () {
+		// make PageIndicator
+		pageIndicator = tau.widget.PageIndicator(elPageIndicator, {numberOfPages: sectionLength});
+		// make SectionChanger object
+		sectionChanger = tau.widget.SectionChanger(changer, {
+			circular: true,
+			orientation: "horizontal",
+			useBouncingEffect: true
+		});
+	});
+
+	/**
+	 * pagehide event handler
+	 * Destroys and removes event listeners
+	 */
+	page.addEventListener("pagehide", function () {
+		// release object
+		sectionChanger.destroy();
+	});
+
+	/**
+	 * sectionchange event handler
+	 * @param {Event} e
+	 */
+	pageIndicatorHandler = function (e) {
+		pageIndicator.setActive(e.detail.active);
+	};
+
+	changer.addEventListener("sectionchange", pageIndicatorHandler, false);
+}());

--- a/js/swipe-control/swipe-control-init.js
+++ b/js/swipe-control/swipe-control-init.js
@@ -1,0 +1,54 @@
+(function() {
+	function init() {
+		initRemoteApi(function onRemoteApiComplete() {
+			loadSettings(function onSettingsComplete(settings) {
+				if (!isEmpty(settings.ip)) {
+					initGestureController(onSwipeUp, onSwipeDown, onSwipeLeft,
+							onSwipeRight, onTap, onDoubleTap, onTwoFingersTap, onTwoFingersDoubleTap,
+							onBezelRotateLeft, onBezelRotateRight);
+				} else {
+					// what else?
+				}
+			});
+		});
+	}
+
+	function onSwipeUp() {
+		sendTvRequest("up");
+	}
+	function onSwipeDown() {
+		sendTvRequest("down");
+	}
+	function onSwipeLeft() {
+		sendTvRequest("left");
+	}
+	function onSwipeRight() {
+		sendTvRequest("right");
+	}
+	function onTap() {
+		sendTvRequest("confirm")
+	}
+	function onDoubleTap() {
+		sendTvRequest("back")
+	}
+	function onTwoFingersTap() {
+		sendTvRequest("home")
+	}
+	function onTwoFingersDoubleTap() {
+		sendTvRequest("options")
+	}
+	function onBezelRotateLeft() {
+		sendTvRequest("volumeDown")
+	}
+	function onBezelRotateRight() {
+		sendTvRequest("volumeUp")
+	}
+
+	window.onload = init;
+	window.addEventListener("tizenhwkey", function(ev) {
+		if (ev.keyName === "back") {
+			window.history.back();
+		}
+	});
+
+}());

--- a/js/swipe-control/swipe-control.js
+++ b/js/swipe-control/swipe-control.js
@@ -1,0 +1,56 @@
+function initGestureController(onSwipeUp, onSwipeDown, onSwipeLeft,
+		onSwipeRight, onTap, onDoubleTap, onTwoFingersTap,
+		onTwoFingersDoubleTap, onBezelRotateLeft, onBezelRotateRight) {
+	var touchArea = document.getElementById("swipe_control_area");
+	var logText = document.getElementById("log_text");
+
+	tau.event.enableGesture(touchArea, new tau.event.gesture.Swipe({
+		orientation : "horizontal"
+	}));
+	tau.event.enableGesture(touchArea, new tau.event.gesture.Swipe({
+		orientation : "vertical"
+	}));
+
+	handleTapEvents(touchArea, function onSingleTapEvent() {
+		logText.innerHTML = "single tap";
+		onTap();
+	}, function onDoubleTapEvent() {
+		logText.innerHTML = "double tap";
+		onDoubleTap();
+	}, function onTwoFingersTapEvent() {
+		logText.innerHTML = "two fingers tap";
+		onTwoFingersTap();
+	}, function onTwoFingersDoubleTapEvent() {
+		logText.innerHTML = "two fingers double tap";
+		onTwoFingersDoubleTap();
+	});
+
+	touchArea.addEventListener("swipe", function onSwipe(e) {
+		switch (e.detail.direction) {
+		case tau.event.gesture.Direction.UP:
+			onSwipeUp();
+			break;
+		case tau.event.gesture.Direction.DOWN:
+			onSwipeDown();
+			break;
+		case tau.event.gesture.Direction.LEFT:
+			onSwipeLeft();
+			break;
+		case tau.event.gesture.Direction.RIGHT:
+			onSwipeRight();
+			break;
+		default:
+		}
+		logText.innerHTML = "direction - " + e.detail.direction
+				+ ", velocity - " + e.detail.velocity + ", timeThreshold - "
+				+ e.detail.timeThreshold;
+	});
+
+	onBezelRotate(function onLeft() {
+		logText.innerHTML = "Bezel left";
+		onBezelRotateLeft();
+	}, function onRight() {
+		logText.innerHTML = "Bezel right";
+		onBezelRotateRight();
+	});
+};

--- a/js/utils/tizen-utils.js
+++ b/js/utils/tizen-utils.js
@@ -1,0 +1,32 @@
+function onBezelRotate(onLeft, onRight) {
+	document.addEventListener('rotarydetent', function(e) {
+		switch (e.detail.direction) {
+		case "CW":
+			onRight();
+			break;
+		case "CCW":
+			onLeft();
+			break;
+		}
+	}, false);
+}
+
+function scrollPageWithBezel(pageId, step) {
+	document.getElementById(pageId).addEventListener('pagebeforeshow',
+			function pageScrollHandler(e) {
+				var scroller = e.target.querySelector('.ui-scroller');
+
+				onBezelRotate(function onLeft() {
+					scroller.scrollTop -= step;
+				}, function onRight() {
+					scroller.scrollTop += step;
+				});
+			});
+}
+
+function scrollWithBezelAsSnapList(pageId, listId) {
+	document.getElementById(pageId).addEventListener('pagebeforeshow', function pageScrollHandler(e) {
+		var list = document.getElementById(listId);
+		tau.helper.SnapListMarqueeStyle.create(list, {marqueeDelay: 1000});
+	});
+}

--- a/js/utils/touch-utils.js
+++ b/js/utils/touch-utils.js
@@ -1,0 +1,53 @@
+var doubleTapTimer = null;
+var twoFingersDoubleTapTimer = null;
+
+var moving = false;
+var touchStartedEvent = null;
+
+function handleTapEvents(view, onSingleTap, onDoubleTap, onTwoFingersTap,
+		onTwoFingersDoubleTap) {
+	view.addEventListener('touchmove', function(e) {
+		moving = true;
+	});
+	view.addEventListener('touchstart', function(e) {
+		moving = false;
+		touchStartedEvent = e;
+	});
+	view.addEventListener('touchend', function(e) {
+		if (moving) {
+			return false;
+		}
+
+		switch (touchStartedEvent.touches.length) {
+		case 2:
+			// if (twoFingersDoubleTapTimer === null) {
+			// twoFingersDoubleTapTimer = setTimeout(function() {
+			// twoFingersDoubleTapTimer = null;
+			// handle single tap
+			onTwoFingersTap();
+			// }, 500);
+			// } else {
+			// clearTimeout(twoFingersDoubleTapTimer);
+			// twoFingersDoubleTapTimer = null;
+			// // handle double tap
+			// onTwoFingersDoubleTap();
+			// }
+			break;
+		}
+		return false;
+	});
+	view.addEventListener('click', function(e) {
+		if (doubleTapTimer === null) {
+			doubleTapTimer = setTimeout(function() {
+				doubleTapTimer = null;
+				// handle single tap
+				onSingleTap();
+			}, 300);
+		} else {
+			clearTimeout(doubleTapTimer);
+			doubleTapTimer = null;
+			// handle double tap
+			onDoubleTap();
+		}
+	});
+}

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1,0 +1,40 @@
+// Returns if a value is a string
+function isString(value) {
+	return typeof value === 'string' || value instanceof String;
+}
+
+// Returns if a value is really a number
+function isNumber(value) {
+	return typeof value === 'number' && isFinite(value);
+}
+
+// Returns if a value is a function
+function isFunction(value) {
+	return typeof value === 'function';
+}
+
+// Returns if a value is an object
+function isObject(value) {
+	return value && typeof value === 'object' && value.constructor === Object;
+}
+
+// Returns if a value is null
+function isNull(value) {
+	return value === null;
+}
+
+// Returns if a value is undefined
+function isUndefined(value) {
+	return typeof value === 'undefined';
+}
+
+function isEmpty(str) {
+    return !str || 0 === str.length;
+}
+
+function hideView(view){
+	view.style.display = "none";
+}
+function showView(view){
+	view.style.display = "block";
+}


### PR DESCRIPTION
Some users will appreciate having a gestures mecanism to navigate your TV, without having to look at your watch in order to hit a button.

This PR introduces a gestures screen dedicated to cover the common navigation commands:
 - bezel rotation to control VOLUME
 - swipe for navigation (UP, DOWN, LEFT, RIGHT)
 - tap (confirm, aka OK)
 - double tap (BACK)
 - two fingers tap (HOME)
 - two fingers double tap (OPTIONS)

P.S. - The above list may change or grow in upcoming PRs